### PR TITLE
Add an `Track.fileSpan` element

### DIFF
--- a/metadata.ts
+++ b/metadata.ts
@@ -81,8 +81,11 @@ export type Track = {
      */
     file?: FilePath,
 
-    // TODO: Do we want a `fileSpan: Span` element, to select only a portion of
-    // a media file?
+    /**
+     * If `file` is a media file, this attribute may optionally be used to play
+     * only a part of the file.
+     */
+    fileSpan?: TimeSpan,
 
     /**
      * Textual context, which should be valid HTML 5, optionally with embedded


### PR DESCRIPTION
This would allow us to specify that a track should only use the specified portion of a media file for a given track.

Do we have a concrete use case for this? It would be nice to supply an example file showing how applications would like to use this.